### PR TITLE
load_param_mem and load_model_mem pybinds

### DIFF
--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -1053,9 +1053,12 @@ PYBIND11_MODULE(ncnn, m)
 #if NCNN_STDIO
 #if NCNN_STRING
         .def("load_param", (int(Net::*)(const char*)) & Net::load_param, py::arg("protopath"))
+        .def("load_param_mem", (int(Net::*)(const char*)) & Net::load_param_mem, py::arg("mem"))
 #endif // NCNN_STRING
         .def("load_param_bin", (int(Net::*)(const char*)) & Net::load_param_bin, py::arg("protopath"))
         .def("load_model", (int(Net::*)(const char*)) & Net::load_model, py::arg("modelpath"))
+        .def(
+            "load_model_mem", [](Net& net, const char* mem) { const unsigned char* mem_array = (const unsigned char*) mem; net.load_model(mem_array); }, py::arg("mem"))
 #endif // NCNN_STDIO
 
         .def("clear", &Net::clear)


### PR DESCRIPTION
load_param_mem takes a str, load_model_mem takes bytes

In minimum example, replace
```
net.load_param("./x4.param")
net.load_model("./x4.bin")
```
with
```
with open("./x4.param", "r") as f:
    net.load_param_mem(f.read())
with open("./x4.bin", "rb") as f:
    net.load_model_mem(f.read())
```